### PR TITLE
Update for new locations of otherlibs

### DIFF
--- a/local-packages/ocamlfind/configure
+++ b/local-packages/ocamlfind/configure
@@ -367,7 +367,7 @@ if ocamlc -config >/dev/null 2>/dev/null; then
 else
     # Old ocamlc do not have -config.
     rm -f itest-aux/simple
-    ocamlc -w a -custom -thread -o itest-aux/simple unix.cma threads.cma itest-aux/simple_threads.ml \
+    ocamlc -w a -custom -thread -o itest-aux/simple -I +unix unix.cma threads.cma itest-aux/simple_threads.ml \
 	>itest-aux/err.out 2>&1
     output=`cat itest-aux/err.out`
 
@@ -392,7 +392,7 @@ echo "Testing DLLs..."
 
 have_dlls="yes"
 
-ocaml unix.cma itest-aux/simple.ml >/dev/null || have_dlls="no"
+ocaml -I +unix unix.cma itest-aux/simple.ml >/dev/null || have_dlls="no"
 
 ######################################################################
 # Does this version of OCaml support extension points?
@@ -573,6 +573,23 @@ else
     lgraphics=""
 fi
 
+if [ -f "${ocaml_core_stdlib}/str/str.cma" ]; then
+    str_dir='+str'
+else
+    str_dir='^'
+fi
+
+if [ -f "${ocaml_core_stdlib}/dynlink/dynlink.cma" ]; then
+    dynlink_dir='+dynlink'
+else
+    dynlink_dir='^'
+fi
+
+if [ -f "${ocaml_core_stdlib}/unix/unix.cma" ]; then
+    unix_dir='+unix'
+else
+    unix_dir='^'
+fi
 
 # Generate the META files now.
 
@@ -590,6 +607,9 @@ for lib in $l; do
     fi
     m4 -Dos=$os \
 	"-Dtype_of_threads=${ocaml_threads}" \
+	"-Dunix_dir=${unix_dir}" \
+	"-Dstr_dir=${str_dir}" \
+	"-Ddynlink_dir=${dynlink_dir}" \
 	"-Dcamlp4_dir=${camlp4_dir}" \
 	"-Dcamlp4_version=${camlp4_version}" \
 	"-Dcamlp4_cmd=${camlp4_cmd}" \

--- a/local-packages/ocamlfind/site-lib-src/dynlink/META.in
+++ b/local-packages/ocamlfind/site-lib-src/dynlink/META.in
@@ -3,7 +3,7 @@ dnl This file is input of the m4 macro processor.
 `requires = ""'
 `version = "[distributed with Ocaml]"'
 `description = "Dynamic loading and linking of object files"'
-`directory = "^"'
+`directory = "'dynlink_dir`"'
 `browse_interfaces = "'interfaces`"'
 `archive(byte) = "dynlink.cma"'
 natdynlink

--- a/local-packages/ocamlfind/site-lib-src/str/META.in
+++ b/local-packages/ocamlfind/site-lib-src/str/META.in
@@ -3,7 +3,7 @@ dnl This file is input of the m4 macro processor.
 `requires = ""'
 `description = "Regular expressions and string processing"'
 `version = "[distributed with Ocaml]"'
-`directory = "^"'
+`directory = "'str_dir`"'
 `browse_interfaces = "'interfaces`"'
 `archive(byte) = "str.cma"'
 `archive(native) = "str.cmxa"'

--- a/local-packages/ocamlfind/site-lib-src/unix/META.in
+++ b/local-packages/ocamlfind/site-lib-src/unix/META.in
@@ -3,7 +3,7 @@ dnl This file is input of the m4 macro processor.
 `requires = ""'
 `description = "Unix system calls"'
 `version = "[distributed with Ocaml]"'
-`directory = "^"'
+`directory = "'unix_dir`"'
 `browse_interfaces = "'interfaces`"'
 `archive(byte) = "unix.cma"'
 `archive(native) = "unix.cmxa"'

--- a/local-packages/ocamlfind/src/findlib/Makefile
+++ b/local-packages/ocamlfind/src/findlib/Makefile
@@ -13,8 +13,8 @@ include $(TOP)/Makefile.config
 NAME = findlib
 
 # Need compiler-libs since ocaml-4.00
-OCAMLC = ocamlc -I +compiler-libs
-OCAMLOPT = ocamlopt -I +compiler-libs -g
+OCAMLC = ocamlc -I +compiler-libs -I +unix -I +dynlink
+OCAMLOPT = ocamlopt -I +compiler-libs -g -I +unix -I +dynlink
 OCAMLDEP = ocamldep
 OCAMLLEX = ocamllex
 #CAMLP4O =  camlp4 pa_o.cmo pa_op.cmo pr_o.cmo --

--- a/local-packages/ocamlfind/tools/extract_args/Makefile
+++ b/local-packages/ocamlfind/tools/extract_args/Makefile
@@ -1,7 +1,7 @@
 all: extract_args
 
 extract_args: extract_args.ml
-	ocamlc -o extract_args str.cma extract_args.ml
+	ocamlc -o extract_args -I +str str.cma extract_args.ml
 
 clean:
 	rm -f *.cmo *.cmi *.cma extract_args


### PR DESCRIPTION
Provides compatibility to silence the alert proposed in ocaml/ocaml#11198. The change is compatible with previous OCaml releases, but it's obviously not worth merging this unless/until the OCaml PR is accepted.