### PR TITLE
Improve compatibility of configure script

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 (cd local-packages/ocamlfind \
-  && ./configure $* )
+  && ./configure "$@" )


### PR DESCRIPTION
- use /bin/sh as we don't rely on any bash features in this simple script
- use "$@" as opposed to $* because it has better quoting behavior see: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_05_02